### PR TITLE
Always return distance, even for unknown airlines

### DIFF
--- a/src/main/kotlin/com/canadiancow/aqd/Itinerary.kt
+++ b/src/main/kotlin/com/canadiancow/aqd/Itinerary.kt
@@ -1,5 +1,6 @@
 package com.canadiancow.aqd
 
+import com.canadiancow.aqd.aqm.getDistanceResult
 import com.canadiancow.aqd.aqm.getEarningResult
 import com.canadiancow.aqd.distance.airports
 
@@ -106,10 +107,11 @@ class Segment(
         bonusMilesPercentage = bonusMilesPercentage
     )
 
-    val distance = earningResult?.distance
+    private val distanceResult = earningResult?.distanceResult ?: getDistanceResult(origin, destination)
+    val distance = distanceResult.distance
 
-    val distanceString = distance?.toString() ?: "???"
-    val distanceSourceString = earningResult?.distanceSource ?: "???"
+    val distanceString = distanceResult.distance?.toString() ?: "???"
+    val distanceSourceString = distanceResult.source ?: "???"
 
     val aqmString = earningResult?.aqm?.toString() ?: "???"
     val aeroplanString = earningResult?.aeroplan?.toString() ?: "???"

--- a/src/main/kotlin/com/canadiancow/aqd/aqm/Calculators.kt
+++ b/src/main/kotlin/com/canadiancow/aqd/aqm/Calculators.kt
@@ -9,7 +9,7 @@ import java.lang.Integer.min
 import kotlin.math.roundToInt
 
 open class EarningResult(
-    distanceResult: DistanceResult,
+    val distanceResult: DistanceResult,
     val aqmPercent: Int,
     val aeroplanPercent: Int = aqmPercent,
     val bonusPercent: Int,
@@ -18,8 +18,7 @@ open class EarningResult(
     val minimumMiles: Int = (aeroplanPercent * baseMinimumMiles / 100.0).roundToInt(),
     val isAqdEligible: Boolean
 ) {
-    val distance = distanceResult.distance
-    val distanceSource = distanceResult.source
+    private val distance = distanceResult.distance
 
     val aqm = when {
         distance == null -> null
@@ -1031,11 +1030,7 @@ fun getEarningResult(
     val destinationCountry = airports[destination]?.country
     val destinationContinent = countriesToContinent[destinationCountry]
 
-    val distanceResult = getSegmentDistance(origin, destination).also {
-        it.error?.let { error ->
-            throw AqdCalculatorException("Error calculating distance for $origin-$destination: $error")
-        }
-    }
+    val distanceResult = getDistanceResult(origin, destination)
 
     return calculator(
         distanceResult,
@@ -1051,4 +1046,10 @@ fun getEarningResult(
         hasAltitudeStatus,
         bonusMilesPercentage
     )
+}
+
+fun getDistanceResult(origin: String, destination: String) = getSegmentDistance(origin, destination).also {
+    it.error?.let { error ->
+        throw AqdCalculatorException("Error calculating distance for $origin-$destination: $error")
+    }
 }

--- a/src/test/kotlin/com/canadiancow/aqd/aqm/AqmTest.kt
+++ b/src/test/kotlin/com/canadiancow/aqd/aqm/AqmTest.kt
@@ -303,7 +303,7 @@ internal class AqmTest {
                 ticketNumber = "014",
                 hasAltitudeStatus = false,
                 bonusMilesPercentage = 0
-            )!!.distance
+            )!!.distanceResult.distance
         )
     }
 
@@ -987,7 +987,7 @@ internal class AqmTest {
             bonusMilesPercentage = 100
         )!!
 
-        assertEquals(4220, earningResult.distance)
+        assertEquals(4220, earningResult.distanceResult.distance)
 
         assertEquals(0, earningResult.aqmPercent)
         assertEquals(0, earningResult.aqm)


### PR DESCRIPTION
Closes #9 

We can't calculate AQM/AQD for unknown airlines, but the actual distance can still be displayed.