### PR TITLE
Eliminate cents in SQD (round to nearest dollar)

### DIFF
--- a/src/main/kotlin/com/canadiancow/sqd/SqdCalculator.kt
+++ b/src/main/kotlin/com/canadiancow/sqd/SqdCalculator.kt
@@ -173,7 +173,7 @@ class SqdCalculator(
     }
 }
 
-private val currencyFormat = DecimalFormat("#,##0.00")
+private val currencyFormat = DecimalFormat("#,##0")
 private fun Double.toCurrencyString() = currencyFormat.format(this)
 
 internal val defaultSegments =


### PR DESCRIPTION
To match Aeroplan rounding to nearest dollar since switch to new program (November 2020)