### PR TITLE
Fix a bug with minimum miles for status

### DIFF
--- a/src/main/kotlin/com/canadiancow/sqd/sqm/Calculators.kt
+++ b/src/main/kotlin/com/canadiancow/sqd/sqm/Calculators.kt
@@ -28,7 +28,7 @@ open class EarningResult(
     val sqm = when {
         distance == null -> null
         sqmPercent == 0 -> 0
-        else -> max(distance * sqmPercent / 100, minimumPoints)
+        else -> max(distance, minimumPoints) * sqmPercent / 100
     }
 
     val aeroplanMiles = when {


### PR DESCRIPTION
It's not `250 or COS*distance`, it's `COS*(250 or distance)`